### PR TITLE
Fixed undefined toJSON by adding it to ignored functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class Server {
       'withLogger',
       'withSuccessHandler',
       'withUserObject',
+      'toJSON',
     ];
 
     this.serverFunctions = {};


### PR DESCRIPTION
Browser was throwing undefined function error for toJSON.  Adding toJSON to list of ignored functions fixes the uncaught exception.