### PR TITLE
Fix/support safari

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,6 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,6 +27,6 @@ jobs:
     - name: Install dependencies
       run: yarn
     - name: Build
-      run: yarn run build --if-present
+      run: yarn build
     - name: Test
       run: yarn test

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "prepack": "yarn build",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
-    "prebuild": "yarn test",
     "build": "babel src/index.js -d build"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A client-side utility class that can call server-side Google Apps Script functions",
   "main": "build/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,7 @@ export default class Server {
           });
       });
     } catch (err) {
-      if (
-        err.toString() === 'ReferenceError: google is not defined' &&
-        process &&
-        process.env &&
-        process.env.NODE_ENV === 'development'
-      ) {
+      if (typeof google === 'undefined') {
         // we'll store and access the resolve/reject functions here by id
         window.gasStore = {};
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,28 +119,7 @@ describe('local development gas-client server', () => {
     expect(server).toHaveProperty('serverFunctions');
   });
 
-  test("should not set up local development behavior if process.env.NODE_ENV is not 'development'", () => {
-    global.process.env = {};
-
-    const server = new Server();
-    expect(server.serverFunctions.someFunction).toBe(undefined);
-    expect(window).not.toHaveProperty('gasStore');
-  });
-
-  test("should set up local development behavior if NODE_ENV is 'development'", () => {
-    global.process.env = { NODE_ENV: 'development' };
-
-    const server = new Server();
-    expect(server.serverFunctions.someFunction).not.toBe(undefined);
-    expect(typeof server.serverFunctions.someFunction).toBe('function');
-    expect(window).toHaveProperty('gasStore');
-  });
-
   describe('when set up properly', () => {
-    beforeEach(() => {
-      global.process.env = { NODE_ENV: 'development' };
-    });
-
     test('should add gasStore to window', () => {
       expect(window).not.toHaveProperty('gasStore');
       new Server();


### PR DESCRIPTION
- Remove requirement to set `process.env.NODE_ENV` to `development` (now do not need to set `NODE_ENV`)
- Update check for existence of `google` global variable to support safari.