### PR TITLE
Add optional chaining for focusEditor in ScriptHostFunctions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-client",
-  "version": "1.2.1-pr.1",
+  "version": "1.2.1",
   "description": "A client-side utility class that can call server-side Google Apps Script functions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-client",
-  "version": "1.2.0",
+  "version": "1.2.1-pr.1",
   "description": "A client-side utility class that can call server-side Google Apps Script functions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/classes/host-functions.ts
+++ b/src/classes/host-functions.ts
@@ -11,7 +11,7 @@ class ScriptHostFunctions extends ScriptHostProvider {
       close: google.script.host.close,
       setHeight: google.script.host.setHeight,
       setWidth: google.script.host.setWidth,
-      focusEditor: google.script.host.editor.focus,
+      focusEditor: google.script.host.editor?.focus,
     };
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -143,6 +143,17 @@ describe('production gas-client server', () => {
 
     expect(global.google.script.host.editor.focus).toHaveBeenCalled();
   });
+
+  test('should handle missing google.script.host.editor property, for webapp projects', () => {
+    // Set up the environment without the editor property
+    delete global.google.script.host.editor;
+    
+    // This should not throw an error when the editor property is missing
+    const server = new GASClient();
+    
+    // The focusEditor property should exist but be undefined
+    expect(server.scriptHostFunctions).toHaveProperty('focusEditor', undefined);
+  });
 });
 describe('local development gas-client server', () => {
   const eventHandlersStore = [];


### PR DESCRIPTION
Hello. I found a bug in v1.2.0.

When GAS is deployed as a simple web application that is not on a Google Docs or Sheets dialog or sidebar, the following error occurs because `google.script.host.editor` is undefined:

```
userCodeAppPanel:104 Uncaught TypeError: Cannot read properties of undefined (reading 'focus')
    at A.initializeScriptHostFunctions (userCodeAppPanel:104:3469)
    at new A (userCodeAppPanel:104:3202)
    at new H (userCodeAppPanel:104:19612)
    at userCodeAppPanel:104:20319
```

Therefore, I've implemented optional chaining so that errors no longer occur even when `google.script.host.editor` is undefined.